### PR TITLE
Fix CloudKit invite handling

### DIFF
--- a/Wya/CloudKitLocationManager.swift
+++ b/Wya/CloudKitLocationManager.swift
@@ -77,12 +77,20 @@ class CloudKitLocationManager: ObservableObject {
 
         let operation = CKModifyRecordsOperation(recordsToSave: [record, share], recordIDsToDelete: nil)
         operation.modifyRecordsCompletionBlock = { [weak self] _, _, error in
-            if let ckError = error as? CKError, ckError.code == .zoneBusy {
-                let delay = (ckError.userInfo[CKErrorRetryAfterKey] as? TimeInterval) ?? 2.0
-                print("Zone is busy, retrying in \(delay)s...")
-
-                DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
-                    self?.createShare(completion: completion) // Retry recursively
+            if let ckError = error as? CKError {
+                switch ckError.code {
+                case .zoneBusy:
+                    let delay = (ckError.userInfo[CKErrorRetryAfterKey] as? TimeInterval) ?? 2.0
+                    print("Zone is busy, retrying in \(delay)s...")
+                    DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+                        self?.createShare(completion: completion)
+                    }
+                case .serverRecordChanged:
+                    print("Share already exists, fetching")
+                    self?.fetchExistingShare(for: record, completion: completion)
+                default:
+                    print("Share creation failed: \(ckError)")
+                    completion(nil, ckError)
                 }
             } else if let error = error {
                 print("Share creation failed: \(error)")
@@ -97,6 +105,25 @@ class CloudKitLocationManager: ObservableObject {
         }
 
         privateDB.add(operation)
+    }
+
+    private func fetchExistingShare(for record: CKRecord, completion: @escaping (CKShare?, Error?) -> Void) {
+        privateDB.fetch(withRecordID: record.recordID) { [weak self] fetchedRecord, error in
+            if let fetchedRecord = fetchedRecord, let shareRef = fetchedRecord.share {
+                self?.privateDB.fetch(withRecordID: shareRef.recordID) { shareRecord, shareError in
+                    if let share = shareRecord as? CKShare {
+                        DispatchQueue.main.async {
+                            self?.share = share
+                        }
+                        completion(share, nil)
+                    } else {
+                        completion(nil, shareError)
+                    }
+                }
+            } else {
+                completion(nil, error)
+            }
+        }
     }
 
     func acceptShare(from url: URL, completion: @escaping (Bool) -> Void) {

--- a/Wya/Info.plist
+++ b/Wya/Info.plist
@@ -10,6 +10,10 @@
         </array>
         <key>NSLocationWhenInUseUsageDescription</key>
         <string>This app uses your location to display it on the map and share with invited friends.</string>
+        <key>CFBundleShortVersionString</key>
+        <string>1.0</string>
+        <key>CFBundleVersion</key>
+        <string>1</string>
         <key>CKContainerIdentifier</key>
         <string>iCloud.com.wyatracker.Wya</string>
 </dict>


### PR DESCRIPTION
## Summary
- handle share already existing when creating the invite
- expose the app version in `Info.plist` so iOS doesn't treat the build as outdated

## Testing
- `xcodebuild -list -project Wya.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b0e3a14708329ae971adc3ccb3e0b