### PR TITLE
Improve CloudKit share handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,6 @@ This project demonstrates a simple location sharing app. Invites are handled usi
 1. **CloudKit Container**: In your Apple Developer account, create a CloudKit container named `iCloud.com.example.Wya`. Update the bundle ID and container identifier to match your app.
 2. **Associated Domains**: Configure an associated domain for universal links (e.g. `applinks:example.com`) in your Apple Developer portal and in `Wya.entitlements`.
 3. **Universal Link Hosting**: Host the Apple App Site Association (AASA) file on your domain to enable Universal Links.
+4. **Production Schema**: If you plan to test with TestFlight, make sure to deploy the CloudKit schema to the production environment so the app can access your records when distributed.
 
 No additional backend servers are required; CloudKit handles sharing and data storage.

--- a/Wya/ContentView.swift
+++ b/Wya/ContentView.swift
@@ -424,14 +424,9 @@ struct PeopleListView: View {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button(action: {
                         print("Invite tapped")
-                        CloudKitLocationManager.shared.createShare { share, error in
-                            if let share = share {
-                                print("Share ready, showing sheet")
-                                DispatchQueue.main.async {
-                                    showingInvite = true
-                                }
-                            } else {
-                                print("Share creation failed: \(String(describing: error))")
+                        CloudKitLocationManager.shared.prepareShare { share in
+                            if share != nil {
+                                showingInvite = true
                             }
                         }
                     }) {
@@ -444,6 +439,12 @@ struct PeopleListView: View {
         .sheet(isPresented: $showingInvite) {
             InviteView()
                 .environmentObject(viewModel)
+        }
+        .alert(isPresented: Binding<Bool>(
+            get: { CloudKitLocationManager.shared.lastError != nil },
+            set: { _ in CloudKitLocationManager.shared.lastError = nil }
+        )) {
+            Alert(title: Text("Error"), message: Text(CloudKitLocationManager.shared.lastError?.localizedDescription ?? "Unknown error"), dismissButton: .default(Text("OK")))
         }
     }
 }

--- a/Wya/Wya.entitlements
+++ b/Wya/Wya.entitlements
@@ -2,8 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>aps-environment</key>
-	<string>development</string>
+        <key>aps-environment</key>
+        <string>production</string>
 	<key>com.apple.developer.applesignin</key>
 	<array>
 		<string>Default</string>


### PR DESCRIPTION
## Summary
- help CloudKit share creation succeed in production
- alert when share creation fails
- switch push environment to production
- document CloudKit production schema in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b1888e8d08329872e5e4a3c0ab614