### PR TITLE
Fix universal link handling

### DIFF
--- a/Wya/WyaApp.swift
+++ b/Wya/WyaApp.swift
@@ -30,8 +30,10 @@ struct WyaApp: App {
                 ContentView(session: session)
                     .environmentObject(session)
                     .preferredColorScheme(.dark)
-                    .onOpenURL { url in
-                        CloudKitLocationManager.shared.acceptShare(from: url) { _ in }
+                    .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { activity in
+                        if let url = activity.webpageURL {
+                            CloudKitLocationManager.shared.acceptShare(from: url) { _ in }
+                        }
                     }
             } else {
                 SignInView()


### PR DESCRIPTION
## Summary
- handle incoming universal links through `onContinueUserActivity`

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -scheme Wya -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b31b15480832994339bb87620af2b