### PR TITLE
Add invite debug output and alert

### DIFF
--- a/Wya/CloudKitLocationManager.swift
+++ b/Wya/CloudKitLocationManager.swift
@@ -152,7 +152,7 @@ class CloudKitLocationManager: ObservableObject {
     }
 
     func acceptShare(from url: URL, completion: @escaping (Bool) -> Void) {
-        print("Received Universal Link: \(url)")
+        print("Accepting share from URL: \(url)")
 
         container.fetchShareMetadata(with: url) { [weak self] metadata, error in
             if let error = error {

--- a/Wya/WyaApp.swift
+++ b/Wya/WyaApp.swift
@@ -13,6 +13,8 @@ import UIKit
 @main
 struct WyaApp: App {
     @StateObject private var session = UserSession()
+    @State private var inviteAlertMessage = ""
+    @State private var showInviteAlert = false
     init() {
         let appearance = UITabBarAppearance()
         appearance.configureWithOpaqueBackground()
@@ -32,8 +34,20 @@ struct WyaApp: App {
                     .preferredColorScheme(.dark)
                     .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { activity in
                         if let url = activity.webpageURL {
-                            CloudKitLocationManager.shared.acceptShare(from: url) { _ in }
+                            CloudKitLocationManager.shared.acceptShare(from: url) { success in
+                                if success {
+                                    inviteAlertMessage = "Invite accepted and connected!"
+                                    print("🎉 Invite accepted and connected!")
+                                } else {
+                                    inviteAlertMessage = "Failed to accept invite."
+                                    print("⚠️ Failed to accept invite.")
+                                }
+                                showInviteAlert = true
+                            }
                         }
+                    }
+                    .alert(inviteAlertMessage, isPresented: $showInviteAlert) {
+                        Button("OK", role: .cancel) {}
                     }
             } else {
                 SignInView()


### PR DESCRIPTION
## Summary
- log when accepting CloudKit share URLs
- alert the user when an invite is accepted or fails

## Testing
- `swiftc Wya/CloudKitLocationManager.swift Wya/WyaApp.swift -o /tmp/test.o` *(fails: no such module 'CloudKit')*

------
https://chatgpt.com/codex/tasks/task_e_684b33ed79248329b5ebb010c337a58e