### PR TITLE
Add manual invite codes

### DIFF
--- a/Wya/ContentView.swift
+++ b/Wya/ContentView.swift
@@ -494,14 +494,7 @@ struct PeopleListView: View {
             .navigationTitle("Your People")
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
-                    Button(action: {
-                        print("Invite tapped")
-                        CloudKitLocationManager.shared.prepareShare { share in
-                            if share != nil {
-                                showingInvite = true
-                            }
-                        }
-                    }) {
+                    Button(action: { showingInvite = true }) {
                         Image(systemName: "person.badge.plus")
                             .font(.title2)
                     }
@@ -509,7 +502,7 @@ struct PeopleListView: View {
             }
         }
         .sheet(isPresented: $showingInvite) {
-            InviteView()
+            InviteCodeView()
                 .environmentObject(viewModel)
         }
         .alert(isPresented: Binding<Bool>(

--- a/Wya/InviteCodeView.swift
+++ b/Wya/InviteCodeView.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+import CloudKit
+
+struct InviteCodeView: View {
+    @State private var inviteCode: String = ""
+    @State private var inputCode: String = ""
+    @State private var alertMessage: String = ""
+    @State private var showAlert = false
+    @Environment(\.dismiss) var dismiss
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section(header: Text("Your Code")) {
+                    if inviteCode.isEmpty {
+                        Button("Generate Code") {
+                            CloudKitLocationManager.shared.prepareShare { share in
+                                if let url = share?.url {
+                                    inviteCode = url.absoluteString
+                                }
+                            }
+                        }
+                    } else {
+                        Text(inviteCode)
+                            .textSelection(.enabled)
+                        Button("Copy") {
+                            UIPasteboard.general.string = inviteCode
+                        }
+                    }
+                }
+
+                Section(header: Text("Enter Code")) {
+                    TextField("Paste code", text: $inputCode)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled(true)
+                    Button("Accept") {
+                        guard let url = URL(string: inputCode) else { return }
+                        CloudKitLocationManager.shared.acceptShare(from: url) { success in
+                            alertMessage = success ? "Invite accepted!" : "Failed to accept invite"
+                            showAlert = true
+                            if success { dismiss() }
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Invites")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Done") { dismiss() }
+                }
+            }
+            .alert(alertMessage, isPresented: $showAlert) {
+                Button("OK", role: .cancel) {}
+            }
+        }
+    }
+}
+
+struct InviteCodeView_Previews: PreviewProvider {
+    static var previews: some View {
+        InviteCodeView()
+    }
+}


### PR DESCRIPTION
## Summary
- add `InviteCodeView` to manually generate and accept invite codes
- hook up People list screen to present `InviteCodeView`

## Testing
- `swiftc -parse Wya/InviteCodeView.swift`
- `swiftc -parse Wya/ContentView.swift`


------
https://chatgpt.com/codex/tasks/task_e_684c028773788329b1dd4e8a6db8f505